### PR TITLE
Updated parameter sets and set default to auth set name

### DIFF
--- a/functions/Get-Gateway.ps1
+++ b/functions/Get-Gateway.ps1
@@ -26,23 +26,26 @@ General notes
 #>
 function Get-Gateway{
     
-        [CmdletBinding()]
+        [CmdletBinding(DefaultParameterSetName='auth')]
         Param
         (
-            [Parameter(Mandatory=$true)]
+            [Parameter(Mandatory=$true, ParameterSetName='auth')]
+	        [Parameter(Mandatory=$true, ParameterSetName='Name')]
+	        [Parameter(Mandatory=$true, ParameterSetName='ID')]
             [string]
             $authToken,
             
-            
-            [Parameter(ParameterSetName='gatewayName')]
+            [Parameter(ParameterSetName='Name')]
+            [Alias('gatewayName')]
             [string]
-            $gatewayName,
+            $Name,
 
-            [Parameter(ParameterSetName='gatewayID')]
+            [Parameter(ParameterSetName='ID')]
+            [Alias('gatewayID')]
             [string]
-            $gatewayID
+            $ID
         )
-    
+
         Begin{
     
             Write-Verbose 'Building Rest API header with authorization token'


### PR DESCRIPTION
This fixes #1 

This allows -auth to be used on it's own but also required when -Name or -ID is used. Set -auth to be the default when no parameter name is specified.

Renamed -gatewayName and -gatewayID to -Name and -ID to keep with common PS parameter names but added the originals in as Aliases so if they are already being used no code changes are necessary.